### PR TITLE
feat(home): premium homepage redesign with procedural 3D hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@react-buddy/ide-toolbox": "^2.4.0",
         "@react-buddy/palette-mui": "^5.0.1",
+        "@react-three/drei": "^9.122.0",
+        "@react-three/fiber": "^8.18.0",
         "@stripe/react-stripe-js": "^2.7.1",
         "@stripe/stripe-js": "^3.5.0",
         "@testing-library/jest-dom": "^5.17.0",
@@ -38,6 +40,7 @@
         "react-material-ui-carousel": "^3.4.2",
         "react-router-dom": "^6.23.1",
         "react-scripts": "^5.0.1",
+        "three": "^0.169.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3132,6 +3135,12 @@
         "postcss": "^8.2"
       }
     },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.4.tgz",
@@ -4676,12 +4685,30 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
       "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -5152,6 +5179,219 @@
         "@mui/icons-material": "^5.0.1",
         "@mui/material": "^5.0.1",
         "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -5673,6 +5913,12 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -5758,6 +6004,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -5931,6 +6183,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5965,7 +6223,6 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5977,6 +6234,15 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -6045,12 +6311,32 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
       "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
       "dependencies": {
         "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -6062,6 +6348,12 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.5",
@@ -6597,6 +6889,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -7599,6 +7909,15 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -7920,6 +8239,15 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-api": {
@@ -8511,6 +8839,24 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-9.1.0.tgz",
       "integrity": "sha512-CpNFuLxiPFxuZqhSKml3M+t0K/484pMAnfYWH14JoD7OZMnmC0Lmo+P7JX9SobqFpRoo7ifA18kOHdxJywYPEA=="
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -9184,6 +9530,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -9418,6 +9773,12 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -10630,6 +10991,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11398,6 +11765,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11555,6 +11928,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -11877,6 +12256,12 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "9.0.21",
@@ -12305,6 +12690,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12590,6 +12981,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -15685,6 +16097,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -15865,6 +16286,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -15969,6 +16400,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -18498,6 +18944,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -18605,6 +19057,16 @@
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prompts": {
@@ -18884,6 +19346,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-credit-cards-2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-credit-cards-2/-/react-credit-cards-2-1.0.3.tgz",
@@ -19038,6 +19512,31 @@
         "@mui/system": "^5.0.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-refresh": {
@@ -19452,6 +19951,21 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -20724,6 +21238,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -21181,6 +21721,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/svg-parser": {
@@ -21676,6 +22225,45 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/throat": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
@@ -21759,6 +22347,36 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/tryer": {
       "version": "1.0.1",
@@ -21899,6 +22517,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -22224,6 +22879,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -22247,6 +22911,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -22446,6 +23119,17 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -23355,6 +24039,35 @@
       "optional": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@react-buddy/ide-toolbox": "^2.4.0",
     "@react-buddy/palette-mui": "^5.0.1",
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.18.0",
     "@stripe/react-stripe-js": "^2.7.1",
     "@stripe/stripe-js": "^3.5.0",
     "@testing-library/jest-dom": "^5.17.0",
@@ -43,6 +45,7 @@
     "react-material-ui-carousel": "^3.4.2",
     "react-router-dom": "^6.23.1",
     "react-scripts": "^5.0.1",
+    "three": "^0.169.0",
     "web-vitals": "^2.1.4"
   },
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -130,3 +130,77 @@ button {
   animation: slideUp 0.5s ease-in-out;
   animation-fill-mode: forwards;
 }
+
+/* ---------- Home redesign: gentle one-shot entrance ----------
+   A load-time fade-up (never a stuck opacity:0 — content is always visible
+   even if JS / IntersectionObserver never run). */
+[data-reveal] {
+  animation: slideUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* ---------- Home redesign: brand marquee ---------- */
+@keyframes ecomMarquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+.ecom-marquee {
+  overflow: hidden;
+  width: 100%;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
+}
+.ecom-marquee__track {
+  display: flex;
+  width: max-content;
+  gap: 16px;
+  animation: ecomMarquee 28s linear infinite;
+}
+.ecom-marquee:hover .ecom-marquee__track {
+  animation-play-state: paused;
+}
+
+/* ---------- Home redesign: soft page aurora ---------- */
+.home-aurora {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
+}
+.home-aurora::before,
+.home-aurora::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.5;
+}
+.home-aurora::before {
+  width: 540px;
+  height: 540px;
+  top: 8%;
+  right: -160px;
+  background: radial-gradient(circle, rgba(40, 116, 240, 0.18), transparent 70%);
+}
+.home-aurora::after {
+  width: 480px;
+  height: 480px;
+  top: 55%;
+  left: -180px;
+  background: radial-gradient(circle, rgba(245, 0, 87, 0.12), transparent 70%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    animation: none !important;
+  }
+  .ecom-marquee__track {
+    animation: none;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -147,7 +147,7 @@ function Footer() {
             <Typography variant="body2" sx={{ color: 'rgba(226,232,240,0.78)', mb: 2 }}>
               Unlock early access to product drops, curated buying guides, and exclusive VIP offers.
             </Typography>
-            <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1, flexWrap: 'nowrap', alignItems: 'stretch' }}>
               <TextField
                 type="email"
                 required
@@ -156,9 +156,9 @@ function Footer() {
                 placeholder="your@email.com"
                 size="small"
                 variant="outlined"
-                sx={{ flexGrow: 1, minWidth: '220px', bgcolor: 'white', borderRadius: 1 }}
+                sx={{ flexGrow: 1, minWidth: 0, bgcolor: 'white', borderRadius: 1 }}
               />
-              <IconButton type="submit" color="primary" sx={{ bgcolor: 'white', '&:hover': { bgcolor: '#e2e8f0' } }}>
+              <IconButton type="submit" color="primary" sx={{ flexShrink: 0, borderRadius: 1.5, bgcolor: 'white', '&:hover': { bgcolor: '#e2e8f0' } }}>
                 <SendIcon />
               </IconButton>
             </Box>

--- a/src/components/HeroScene.jsx
+++ b/src/components/HeroScene.jsx
@@ -1,0 +1,136 @@
+import React, { useMemo, useRef, useEffect, Suspense } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Float, Environment, Lightformer, Sparkles, RoundedBox } from '@react-three/drei';
+import * as THREE from 'three';
+
+/**
+ * HeroScene — a fully procedural react-three-fiber backdrop for the storefront
+ * hero. No .glb / .hdr / image assets: geometry primitives, metallic standard
+ * materials, and inline Lightformers for glossy reflections.
+ *
+ * A glossy "signature" torus-knot floats among scattered tech-shapes, the whole
+ * rig drifts toward the cursor, and a sparkle field adds premium dust. Lazy
+ * loaded and only mounted on capable GPUs (Home decides), so weak devices fall
+ * back to a pure-CSS gradient hero.
+ */
+
+const BLUE = '#2874f0';
+const PINK = '#f50057';
+const INDIGO = '#4f46e5';
+const SKY = '#38bdf8';
+
+function SignatureKnot({ quality }) {
+  const ref = useRef();
+  useFrame((_, delta) => {
+    if (ref.current) {
+      ref.current.rotation.y += delta * 0.25;
+      ref.current.rotation.z += delta * 0.08;
+    }
+  });
+  const seg = quality === 'high' ? [220, 32] : [140, 20];
+  return (
+    <Float speed={1.4} rotationIntensity={0.5} floatIntensity={0.9}>
+      <mesh ref={ref} scale={1.15}>
+        <torusKnotGeometry args={[1.1, 0.34, seg[0], seg[1]]} />
+        <meshStandardMaterial
+          color={BLUE}
+          metalness={0.95}
+          roughness={0.12}
+          envMapIntensity={1.6}
+        />
+      </mesh>
+    </Float>
+  );
+}
+
+function FloatingShapes() {
+  const shapes = useMemo(
+    () => [
+      { type: 'ico', pos: [-3.4, 1.5, -1], scale: 0.62, color: PINK },
+      { type: 'box', pos: [3.3, 1.9, -1.5], scale: 0.6, color: SKY },
+      { type: 'octa', pos: [3.6, -1.6, -0.5], scale: 0.7, color: INDIGO },
+      { type: 'box', pos: [-3.6, -1.7, -1], scale: 0.5, color: BLUE },
+      { type: 'ico', pos: [-1.6, 2.6, -2], scale: 0.42, color: SKY },
+      { type: 'octa', pos: [2.0, 2.5, -2.4], scale: 0.5, color: PINK },
+    ],
+    [],
+  );
+  return (
+    <>
+      {shapes.map((s, i) => (
+        <Float key={i} speed={1 + (i % 4) * 0.25} rotationIntensity={1.1} floatIntensity={1.4}>
+          {s.type === 'box' ? (
+            <RoundedBox args={[1, 1, 1]} radius={0.16} smoothness={4} position={s.pos} scale={s.scale}>
+              <meshStandardMaterial color={s.color} metalness={0.85} roughness={0.18} envMapIntensity={1.3} />
+            </RoundedBox>
+          ) : (
+            <mesh position={s.pos} scale={s.scale}>
+              {s.type === 'ico' ? <icosahedronGeometry args={[1, 0]} /> : <octahedronGeometry args={[1, 0]} />}
+              <meshStandardMaterial color={s.color} metalness={0.85} roughness={0.2} envMapIntensity={1.3} flatShading />
+            </mesh>
+          )}
+        </Float>
+      ))}
+    </>
+  );
+}
+
+function Rig({ pointerRef, quality }) {
+  const group = useRef();
+  useFrame((_, delta) => {
+    if (!group.current) return;
+    const p = pointerRef.current;
+    group.current.rotation.y = THREE.MathUtils.damp(group.current.rotation.y, p.x * 0.4, 4, delta);
+    group.current.rotation.x = THREE.MathUtils.damp(group.current.rotation.x, -p.y * 0.25, 4, delta);
+    group.current.position.x = THREE.MathUtils.damp(group.current.position.x, p.x * 0.5, 4, delta);
+  });
+  return (
+    <group ref={group}>
+      <SignatureKnot quality={quality} />
+      <FloatingShapes />
+      <Sparkles count={quality === 'high' ? 80 : 40} scale={[12, 7, 5]} size={3} speed={0.3} opacity={0.6} color="#ffffff" />
+    </group>
+  );
+}
+
+const HeroScene = ({ quality = 'mid', onLost }) => {
+  const pointerRef = useRef({ x: 0, y: 0 });
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const onMove = e => {
+      pointerRef.current = {
+        x: (e.clientX / window.innerWidth) * 2 - 1,
+        y: -((e.clientY / window.innerHeight) * 2 - 1),
+      };
+    };
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => window.removeEventListener('pointermove', onMove);
+  }, []);
+
+  return (
+    <Canvas
+      dpr={[1, quality === 'high' ? 1.8 : 1.3]}
+      camera={{ position: [0, 0, 8], fov: 42 }}
+      gl={{ antialias: quality === 'high', alpha: true, powerPreference: 'high-performance', failIfMajorPerformanceCaveat: false }}
+      onCreated={({ gl }) => {
+        gl.domElement.addEventListener('webglcontextlost', e => { e.preventDefault(); if (onLost) onLost(); }, { once: true });
+      }}
+      style={{ width: '100%', height: '100%', pointerEvents: 'none' }}
+    >
+      <Suspense fallback={null}>
+        <ambientLight intensity={0.55} />
+        <pointLight position={[6, 5, 6]} intensity={1.4} color={BLUE} />
+        <pointLight position={[-6, -3, 3]} intensity={1.1} color={PINK} />
+        <Rig pointerRef={pointerRef} quality={quality} />
+        <Environment resolution={256} frames={1}>
+          <color attach="background" args={['#0a0f1f']} />
+          <Lightformer intensity={2.4} position={[4, 3, 4]} scale={[7, 7, 1]} color="#ffffff" />
+          <Lightformer intensity={2} position={[-5, -1, 3]} scale={[6, 6, 1]} color={BLUE} />
+          <Lightformer intensity={1.6} position={[0, 4, -4]} scale={[10, 4, 1]} color={PINK} />
+        </Environment>
+      </Suspense>
+    </Canvas>
+  );
+};
+
+export default HeroScene;

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -9,8 +9,12 @@ import Stack from '@mui/material/Stack';
 import Chip from '@mui/material/Chip';
 import Rating from '@mui/material/Rating';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
 import Tooltip from '@mui/material/Tooltip';
+import AddShoppingCartRoundedIcon from '@mui/icons-material/AddShoppingCartRounded';
 import { useNavigate } from 'react-router-dom';
+
+const ACCENT_GRADIENT = 'linear-gradient(120deg, #38bdf8 0%, #2874f0 45%, #f50057 100%)';
 
 export default function ProductCard({ product, addToCart }) {
   const navigate = useNavigate();
@@ -41,17 +45,31 @@ export default function ProductCard({ product, addToCart }) {
         cursor: 'pointer',
         display: 'flex',
         flexDirection: 'column',
-        transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+        border: '1px solid rgba(15,23,42,0.06)',
+        transition: 'transform 0.35s cubic-bezier(0.22,1,0.36,1), box-shadow 0.35s ease, border-color 0.35s ease',
         '&:hover': {
-          transform: 'translateY(-6px)',
-          boxShadow: '0 24px 38px rgba(15, 23, 42, 0.12)',
+          transform: 'translateY(-8px)',
+          boxShadow: '0 28px 50px rgba(40, 116, 240, 0.18)',
+          borderColor: 'rgba(40,116,240,0.35)',
+        },
+        '&:hover .product-media': {
+          transform: 'scale(1.07)',
         },
       }}
       onClick={handleCardClick}
     >
-      <Box sx={{ position: 'relative', pt: '75%', overflow: 'hidden', borderRadius: '18px 18px 0 0' }}>
+      <Box
+        sx={{
+          position: 'relative',
+          pt: '75%',
+          overflow: 'hidden',
+          borderRadius: '18px 18px 0 0',
+          background: '#ffffff',
+        }}
+      >
         <CardMedia
           component="img"
+          className="product-media"
           alt={product.name}
           src={product.image}
           loading="eager"
@@ -62,10 +80,8 @@ export default function ProductCard({ product, addToCart }) {
             width: '100%',
             height: '100%',
             objectFit: 'contain',
-            transition: 'transform 0.3s ease',
-            '&:hover': {
-              transform: 'scale(1.04)',
-            },
+            p: 2,
+            transition: 'transform 0.45s cubic-bezier(0.22,1,0.36,1)',
           }}
         />
         {formattedCategory && (
@@ -84,6 +100,8 @@ export default function ProductCard({ product, addToCart }) {
           />
         )}
       </Box>
+
+      <Divider />
 
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">
@@ -118,10 +136,12 @@ export default function ProductCard({ product, addToCart }) {
         <Button
           size="small"
           variant="contained"
+          startIcon={<AddShoppingCartRoundedIcon />}
           onClick={event => {
             event.stopPropagation();
             addToCart(product);
           }}
+          sx={{ background: ACCENT_GRADIENT, boxShadow: '0 10px 22px rgba(40,116,240,0.3)', '&:hover': { boxShadow: '0 14px 28px rgba(245,0,87,0.32)' } }}
         >
           Add to Cart
         </Button>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,7 +9,6 @@ import {
   Alert,
   AlertTitle,
   Paper,
-  styled,
   Pagination,
   Stack,
   Link,
@@ -21,11 +20,7 @@ import {
   InputAdornment,
   useMediaQuery,
 } from '@mui/material';
-import Carousel from 'react-material-ui-carousel';
 import ProductCard from '../components/ProductCard';
-import summerSaleImage from '../assets/images/summer-sale.jpg';
-import techGadgetsImage from '../assets/images/tech-gadgets.jpg';
-import trendingFashionImage from '../assets/images/trending-fashion.png';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -37,33 +32,57 @@ import LockIcon from '@mui/icons-material/Lock';
 import SyncIcon from '@mui/icons-material/Sync';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import StarIcon from '@mui/icons-material/Star';
+import StarRoundedIcon from '@mui/icons-material/StarRounded';
 import FormatQuoteRoundedIcon from '@mui/icons-material/FormatQuoteRounded';
 import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded';
+import LocalOfferRoundedIcon from '@mui/icons-material/LocalOfferRounded';
+import BoltRoundedIcon from '@mui/icons-material/BoltRounded';
+import VerifiedRoundedIcon from '@mui/icons-material/VerifiedRounded';
 import '../App.css';
 import { apiClient, withRetry } from '../services/apiClient';
 import { useNotifier } from '../context/NotificationProvider';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 
-const StyledCarousel = styled(Carousel)({
-  height: '100%',
-  '& .CarouselItem': {
-    overflow: 'hidden',
-    borderRadius: 0,
-  },
-  '& .MuiPaper-root': {
-    overflow: 'hidden',
-    borderRadius: 0,
-  },
-  '& .Carousel-indicators-container': {
-    bottom: '20px',
-    '& button': {
-      backgroundColor: 'white',
-      opacity: 0.6,
-      '&:hover': { opacity: 1 },
-      '&.selected': { opacity: 1 },
-    },
-  },
-});
+// The 3D hero backdrop ships in its own lazy chunk and is only mounted on
+// capable GPUs (see detectGpuTier). Weak / reduced-motion devices keep the
+// pure-CSS gradient hero.
+const HeroScene = React.lazy(() => import('../components/HeroScene'));
+
+// Keeps the hero alive if WebGL throws or the 3D chunk fails to load.
+class HeroSceneBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { failed: false };
+  }
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  componentDidCatch() {}
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+function detectGpuTier() {
+  if (typeof window === 'undefined') return 'none';
+  const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let gl = null;
+  try {
+    const c = document.createElement('canvas');
+    gl = c.getContext('webgl2') || c.getContext('webgl') || c.getContext('experimental-webgl');
+  } catch (e) {
+    gl = null;
+  }
+  if (!gl) return 'none';
+  const cores = navigator.hardwareConcurrency || 4;
+  const mem = navigator.deviceMemory || 4;
+  if (reduce || mem <= 2 || cores <= 2) return 'none';
+  if (cores <= 4 || window.innerWidth < 700) return 'mid';
+  return 'high';
+}
+
+const ACCENT_GRADIENT = 'linear-gradient(120deg, #38bdf8 0%, #2874f0 45%, #f50057 100%)';
 
 const normalizeProduct = p => {
   const canonical = p._id || p.id;
@@ -203,6 +222,43 @@ function RecommendedEmpty({ onExplore }) {
   );
 }
 
+/* ---------- Reusable section heading ---------- */
+function SectionHeading({ eyebrow, title, subtitle, align = 'center' }) {
+  return (
+    <Box sx={{ textAlign: align, mb: 4, maxWidth: align === 'center' ? 720 : 'none', mx: align === 'center' ? 'auto' : 0 }}>
+      {eyebrow && (
+        <Typography
+          component="span"
+          sx={{
+            display: 'inline-block',
+            mb: 1.5,
+            px: 1.5,
+            py: 0.5,
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'primary.main',
+            bgcolor: 'rgba(40,116,240,0.10)',
+            border: '1px solid rgba(40,116,240,0.18)',
+          }}
+        >
+          {eyebrow}
+        </Typography>
+      )}
+      <Typography variant="h4" fontWeight={800} sx={{ letterSpacing: '-0.02em' }}>
+        {title}
+      </Typography>
+      {subtitle && (
+        <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+          {subtitle}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
 /* --------------------------------------------------- */
 
 function Home({ products, addToCart, error, loading }) {
@@ -241,7 +297,11 @@ function Home({ products, addToCart, error, loading }) {
   const { notify } = useNotifier();
   const isSmall = useMediaQuery('(max-width:900px)');
   const navigate = useNavigate();
-  const heroHeight = isSmall ? 420 : 560;
+  const heroHeight = isSmall ? 520 : 620;
+
+  const gpuTier = React.useMemo(detectGpuTier, []);
+  const [sceneLost, setSceneLost] = React.useState(false);
+  const show3D = (gpuTier === 'mid' || gpuTier === 'high') && !sceneLost;
 
   /* Featured card animation */
   React.useEffect(() => {
@@ -306,12 +366,6 @@ function Home({ products, addToCart, error, loading }) {
   const recToShow = recs.slice(recStart, recStart + recPerPage).map(normalizeProduct);
   const handleRecPageChange = (_e, value) => setRecPage(value);
 
-  const bannerImages = [
-    { url: summerSaleImage, title: 'Summer Sale - Up to 50% Off', description: 'Shop now for the best deals on summer essentials!' },
-    { url: techGadgetsImage, title: 'New Tech Gadgets', description: 'Explore the latest in tech and gadgets.' },
-    { url: trendingFashionImage, title: 'Trending Electronics', description: 'Discover the newest trends in electronics this season.' },
-  ];
-
   const handleNewsletterSubmit = event => {
     event.preventDefault();
     const email = newsletterEmail.trim();
@@ -334,150 +388,201 @@ function Home({ products, addToCart, error, loading }) {
   };
 
   return (
-    <Box sx={{ my: { xs: 2, md: 4 } }}>
+    <Box sx={{ my: { xs: 2, md: 4 }, position: 'relative' }}>
+      <Box className="home-aurora" aria-hidden="true" />
+      {/* ============================ HERO ============================ */}
       <Paper
         elevation={0}
         sx={{
-          borderRadius: 5,
+          position: 'relative',
+          isolation: 'isolate',
+          borderRadius: 6,
           overflow: 'hidden',
           mb: 5,
-          position: 'relative',
-          background: 'linear-gradient(120deg, rgba(40,116,240,0.92) 0%, rgba(63,81,181,0.82) 100%)',
           minHeight: heroHeight,
+          color: 'white',
+          background: 'radial-gradient(120% 120% at 80% 0%, #16234a 0%, #0b1124 55%, #070a17 100%)',
         }}
       >
-        <Grid container sx={{ height: '100%' }} alignItems="stretch">
-          <Grid
-            item
-            xs={12}
-            md={6}
-            sx={{
-              p: { xs: 4, md: 8 },
-              color: 'white',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'space-between',
-              gap: 3,
-              minHeight: heroHeight,
-            }}
-          >
-            <Chip label="Summer Tech Edit" sx={{ alignSelf: 'flex-start', bgcolor: 'rgba(255,255,255,0.2)', color: 'white', fontWeight: 600 }} />
-            <Box>
-              <Typography variant={isSmall ? 'h4' : 'h3'} fontWeight={800} gutterBottom color="common.white">
-                Gear that upgrades every moment of your day.
+        {/* Procedural 3D backdrop (capable GPUs only) */}
+        {show3D && (
+          <Box sx={{ position: 'absolute', inset: 0, zIndex: 0 }} aria-hidden="true">
+            <HeroSceneBoundary>
+              <React.Suspense fallback={null}>
+                <HeroScene quality={gpuTier} onLost={() => setSceneLost(true)} />
+              </React.Suspense>
+            </HeroSceneBoundary>
+          </Box>
+        )}
+
+        {/* Legibility scrim — keeps copy crisp over the moving 3D */}
+        <Box
+          aria-hidden="true"
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1,
+            background: {
+              xs: 'linear-gradient(180deg, rgba(7,10,23,0.35) 0%, rgba(7,10,23,0.85) 100%)',
+              md: 'linear-gradient(90deg, rgba(7,10,23,0.92) 0%, rgba(7,10,23,0.55) 42%, rgba(7,10,23,0) 70%)',
+            },
+          }}
+        />
+
+        <Grid container sx={{ position: 'relative', zIndex: 2, minHeight: heroHeight }} alignItems="center">
+          <Grid item xs={12} md={7} lg={6} sx={{ p: { xs: 4, md: 8 } }}>
+            <Stack spacing={3} alignItems="flex-start">
+              <Chip
+                icon={<AutoAwesomeRoundedIcon sx={{ color: 'white !important' }} />}
+                label="Summer Tech Edit"
+                sx={{ bgcolor: 'rgba(255,255,255,0.12)', color: 'white', fontWeight: 600, backdropFilter: 'blur(6px)', border: '1px solid rgba(255,255,255,0.18)' }}
+              />
+              <Typography
+                variant={isSmall ? 'h3' : 'h2'}
+                fontWeight={800}
+                sx={{ color: '#fff', lineHeight: 1.05, letterSpacing: '-0.03em', fontSize: { xs: '2.6rem', md: '3.8rem' } }}
+              >
+                Gear that upgrades every{' '}
+                <Box
+                  component="span"
+                  sx={{ background: ACCENT_GRADIENT, WebkitBackgroundClip: 'text', backgroundClip: 'text', WebkitTextFillColor: 'transparent', color: 'transparent' }}
+                >
+                  moment
+                </Box>{' '}
+                of your day.
               </Typography>
-              <Typography variant="body1" sx={{ maxWidth: 440, lineHeight: 1.8 }}>
-                Discover handpicked gadgets, smart home essentials, and creator-ready accessories curated by our in-house specialists.
+              <Typography variant="body1" sx={{ maxWidth: 480, lineHeight: 1.8, color: 'rgba(255,255,255,0.78)' }}>
+                Discover handpicked gadgets, smart-home essentials, and creator-ready accessories curated by our in-house specialists.
               </Typography>
-            </Box>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-              <Button variant="contained" size="large" endIcon={<ArrowForwardIcon />} component={RouterLink} to="/shop">
-                Shop best sellers
-              </Button>
-              <Button variant="outlined" size="large" color="inherit" component={RouterLink} to="/about">
-                Learn our story
-              </Button>
-            </Stack>
-            <Stack direction="row" spacing={3}>
-              <Stack spacing={0.5}>
-                <Typography variant="h5" fontWeight={700}>
-                  4.8/5
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.8 }}>
-                  Rated by 12k+ customers
-                </Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: { xs: '100%', sm: 'auto' } }}>
+                <Button
+                  variant="contained"
+                  size="large"
+                  endIcon={<ArrowForwardIcon />}
+                  component={RouterLink}
+                  to="/shop"
+                  sx={{ px: 3.5, py: 1.4, background: ACCENT_GRADIENT, boxShadow: '0 16px 38px rgba(40,116,240,0.45)', '&:hover': { boxShadow: '0 20px 46px rgba(245,0,87,0.4)' } }}
+                >
+                  Shop best sellers
+                </Button>
+                <Button
+                  variant="outlined"
+                  size="large"
+                  color="inherit"
+                  component={RouterLink}
+                  to="/about"
+                  sx={{ px: 3.5, py: 1.4, borderColor: 'rgba(255,255,255,0.4)', '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.06)' } }}
+                >
+                  Learn our story
+                </Button>
               </Stack>
-              <Stack spacing={0.5}>
-                <Typography variant="h5" fontWeight={700}>
-                  48h
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.8 }}>
-                  Average delivery time
-                </Typography>
+              <Stack direction="row" spacing={4} sx={{ pt: 1 }} divider={<Divider orientation="vertical" flexItem sx={{ borderColor: 'rgba(255,255,255,0.18)' }} />}>
+                <Stack spacing={0.3}>
+                  <Typography variant="h5" fontWeight={800}>
+                    4.8/5
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.65)' }}>
+                    12k+ reviews
+                  </Typography>
+                </Stack>
+                <Stack spacing={0.3}>
+                  <Typography variant="h5" fontWeight={800}>
+                    48h
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.65)' }}>
+                    Avg. delivery
+                  </Typography>
+                </Stack>
+                <Stack spacing={0.3}>
+                  <Typography variant="h5" fontWeight={800}>
+                    50k+
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.65)' }}>
+                    Happy members
+                  </Typography>
+                </Stack>
               </Stack>
             </Stack>
           </Grid>
-          <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
-            <Box sx={{ flex: 1, position: 'relative', minHeight: heroHeight }}>
-              <StyledCarousel
-                height={heroHeight}
-                animation="slide"
-                autoPlay
-                interval={3500}
-                navButtonsAlwaysVisible
-                indicatorIconButtonProps={{ style: { padding: 10 } }}
-                navButtonsProps={{ style: { backgroundColor: 'rgba(17, 24, 39, 0.45)' } }}
-              >
-                {bannerImages.map(item => (
-                  <Box key={item.title} sx={{ height: '100%', position: 'relative' }}>
-                    <Box
-                      component="img"
-                      src={item.url}
-                      alt={item.title}
-                      sx={{
-                        width: '100%',
-                        height: '100%',
-                        objectFit: 'cover',
-                        borderRadius: '8px',
-                      }}
-                    />
-                    <Box
-                      sx={{
-                        position: 'absolute',
-                        inset: 0,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'flex-end',
-                        background: 'linear-gradient(180deg, rgba(10,13,28,0.05) 0%, rgba(10,13,28,0.75) 100%)',
-                        color: '#fff',
-                        p: { xs: 2, md: 3 },
-                        borderRadius: '8px',
-                      }}
-                    >
-                      <Typography variant="h5" fontWeight={700} gutterBottom>
-                        {item.title}
-                      </Typography>
-                      <Typography variant="body2" sx={{ maxWidth: 520 }}>
-                        {item.description}
-                      </Typography>
-                    </Box>
-                  </Box>
+
+          {/* Floating glass trust card (desktop) — balances the composition */}
+          <Grid item xs={12} md={5} lg={6} sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: 'flex-end', p: { md: 8 } }}>
+            <Paper
+              elevation={0}
+              sx={{
+                p: 3,
+                width: 280,
+                borderRadius: 4,
+                bgcolor: 'rgba(255,255,255,0.08)',
+                border: '1px solid rgba(255,255,255,0.16)',
+                backdropFilter: 'blur(14px)',
+                color: 'white',
+              }}
+            >
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                {[0, 1, 2, 3, 4].map(i => (
+                  <StarRoundedIcon key={i} sx={{ color: '#fbbf24', fontSize: 20 }} />
                 ))}
-              </StyledCarousel>
-            </Box>
+              </Stack>
+              <Typography variant="subtitle1" fontWeight={700}>
+                Trusted by 50,000+ builders
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', mt: 0.5, mb: 2 }}>
+                Premium gear, expert curation, and delivery you can count on.
+              </Typography>
+              <Stack spacing={1.2}>
+                {[
+                  { icon: <BoltRoundedIcon fontSize="small" />, label: 'Same-week express shipping' },
+                  { icon: <VerifiedRoundedIcon fontSize="small" />, label: 'Authentic, warrantied products' },
+                  { icon: <LockIcon fontSize="small" />, label: 'Encrypted, secure checkout' },
+                ].map(item => (
+                  <Stack key={item.label} direction="row" spacing={1.2} alignItems="center">
+                    <Box sx={{ display: 'grid', placeItems: 'center', width: 28, height: 28, borderRadius: 2, background: ACCENT_GRADIENT }}>{item.icon}</Box>
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.85)' }}>
+                      {item.label}
+                    </Typography>
+                  </Stack>
+                ))}
+              </Stack>
+            </Paper>
           </Grid>
         </Grid>
       </Paper>
 
       <Container maxWidth="xl">
-        <Grid container spacing={2} sx={{ mb: 6 }}>
+        {/* ====================== VALUE PROPS ====================== */}
+        <Grid container spacing={2.5} sx={{ mb: 8 }} data-reveal="true">
           {valueProps.map(card => (
             <Grid item xs={12} sm={6} md={3} key={card.title}>
-              <Paper elevation={0} sx={{ p: 3, height: '100%', borderRadius: 4, backdropFilter: 'blur(6px)' }}>
-                <Stack direction="row" spacing={2} alignItems="flex-start">
-                  <Avatar sx={{ bgcolor: 'primary.main', color: 'white' }}>{card.icon}</Avatar>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={700} gutterBottom>
-                      {card.title}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {card.description}
-                    </Typography>
+              <Paper
+                elevation={0}
+                sx={{
+                  p: 3,
+                  height: '100%',
+                  borderRadius: 4,
+                  border: '1px solid rgba(15,23,42,0.06)',
+                  transition: 'transform 0.3s cubic-bezier(0.22,1,0.36,1), box-shadow 0.3s ease',
+                  '&:hover': { transform: 'translateY(-6px)', boxShadow: '0 24px 50px rgba(40,116,240,0.16)' },
+                }}
+              >
+                <Stack spacing={1.5}>
+                  <Box sx={{ display: 'grid', placeItems: 'center', width: 52, height: 52, borderRadius: 3, color: 'white', background: ACCENT_GRADIENT, boxShadow: '0 12px 24px rgba(40,116,240,0.3)' }}>
+                    {card.icon}
                   </Box>
+                  <Typography variant="subtitle1" fontWeight={700}>
+                    {card.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {card.description}
+                  </Typography>
                 </Stack>
               </Paper>
             </Grid>
           ))}
         </Grid>
 
-        <Box sx={{ textAlign: 'center', mb: 1 }}>
-          <Typography variant="h4" fontWeight={700}>
-            Featured Products
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Check out our top picks for this month!
-          </Typography>
-        </Box>
+        {/* ====================== FEATURED ====================== */}
+        <SectionHeading eyebrow="Editor's picks" title="Featured Products" subtitle="Our specialists' top picks for this month — tried, tested, and loved." />
 
         {error ? (
           <Alert severity="error" sx={{ maxWidth: 560, mx: 'auto' }}>
@@ -497,21 +602,74 @@ function Home({ products, addToCart, error, loading }) {
           </Grid>
         )}
 
-        <Box sx={{ mt: 8 }}>
-          <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} alignItems={{ xs: 'flex-start', md: 'center' }} justifyContent="space-between">
+        {/* ====================== SPOTLIGHT PROMO ====================== */}
+        <Paper
+          elevation={0}
+          data-reveal="true"
+          sx={{
+            mt: 12,
+            p: { xs: 4, md: 7 },
+            borderRadius: 6,
+            position: 'relative',
+            overflow: 'hidden',
+            color: 'white',
+            background: 'linear-gradient(115deg, #2563eb 0%, #1e3a8a 44%, #131c3f 74%, #0b1124 100%)',
+            boxShadow: '0 30px 70px rgba(15,23,42,0.25)',
+          }}
+        >
+          {/* Crisp, contained accents — a soft top-right sheen + a fading dot grid (no blurry splotches). */}
+          <Box aria-hidden="true" sx={{ position: 'absolute', inset: 0, background: 'radial-gradient(55% 120% at 100% 0%, rgba(56,189,248,0.30), transparent 55%)' }} />
+          <Box
+            aria-hidden="true"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0.45,
+              backgroundImage: 'radial-gradient(rgba(255,255,255,0.14) 1px, transparent 1px)',
+              backgroundSize: '22px 22px',
+              WebkitMaskImage: 'linear-gradient(90deg, #000 0%, transparent 65%)',
+              maskImage: 'linear-gradient(90deg, #000 0%, transparent 65%)',
+            }}
+          />
+          <Grid container spacing={3} alignItems="center" sx={{ position: 'relative', zIndex: 1 }}>
+            <Grid item xs={12} md={8}>
+              <Typography component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, mb: 1.5, fontSize: 12, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.85)' }}>
+                <LocalOfferRoundedIcon sx={{ fontSize: 16 }} /> Member exclusive
+              </Typography>
+              <Typography variant="h3" fontWeight={800} sx={{ color: '#fff', letterSpacing: '-0.02em', mb: 1.5, fontSize: { xs: '2rem', md: '2.6rem' } }}>
+                Up to 40% off premium audio & smart home.
+              </Typography>
+              <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.82)', maxWidth: 560, lineHeight: 1.7 }}>
+                Hand-picked bundles refreshed every week — with free express shipping, easy 30-day returns, and concierge setup help on every order.
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={4} sx={{ textAlign: { md: 'right' } }}>
+              <Button variant="contained" size="large" component={RouterLink} to="/shop" endIcon={<ArrowForwardIcon />} sx={{ px: 4, py: 1.4, bgcolor: '#fff', color: '#0b1124', fontWeight: 700, '&:hover': { bgcolor: 'rgba(255,255,255,0.88)' } }}>
+                Shop the collection
+              </Button>
+            </Grid>
+          </Grid>
+        </Paper>
+
+        {/* ====================== NEW ARRIVALS ====================== */}
+        <Box sx={{ mt: 10 }} data-reveal="true">
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'flex-end' }} justifyContent="space-between" sx={{ mb: 3 }}>
             <Box>
-              <Typography variant="h4" fontWeight={700}>
+              <Typography component="span" sx={{ display: 'inline-block', mb: 1, fontSize: 12, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'primary.main' }}>
+                Just landed
+              </Typography>
+              <Typography variant="h4" fontWeight={800} sx={{ letterSpacing: '-0.02em' }}>
                 New Arrivals
               </Typography>
-              <Typography variant="body1" color="text.secondary">
+              <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5 }}>
                 Fresh drops from brands we love. Updated every week.
               </Typography>
             </Box>
-            <Button variant="text" endIcon={<ArrowForwardIcon />} href="/shop">
+            <Button variant="text" endIcon={<ArrowForwardIcon />} component={RouterLink} to="/shop">
               View all products
             </Button>
           </Stack>
-          <Grid container spacing={4} sx={{ mt: 2 }}>
+          <Grid container spacing={4}>
             {newArrivals.map(product => (
               <Grid item key={product.id} xs={12} sm={6} md={4}>
                 <ProductCard product={product} addToCart={addToCart} />
@@ -520,44 +678,45 @@ function Home({ products, addToCart, error, loading }) {
           </Grid>
         </Box>
 
+        {/* ====================== CATEGORIES ====================== */}
         {!!categories.length && (
-          <Box sx={{ mt: 10 }}>
-            <Typography variant="h4" fontWeight={700} textAlign="center">
-              Shop by Category
-            </Typography>
-            <Typography variant="body1" color="text.secondary" textAlign="center" sx={{ mb: 4 }}>
-              Discover essentials across sound, home, fitness, and creative workflows.
-            </Typography>
-            <Grid container spacing={3}>
+          <Box sx={{ mt: 12 }} data-reveal="true">
+            <SectionHeading eyebrow="Browse" title="Shop by Category" subtitle="Discover essentials across sound, home, fitness, and creative workflows." />
+            <Grid container spacing={3} justifyContent="center">
               {categories.map(category => (
-                <Grid item xs={12} sm={4} md={2} key={category.key}>
+                <Grid item xs={6} sm={4} md={categories.length <= 3 ? 3 : 2} key={category.key}>
                   <Paper
                     elevation={0}
                     sx={{
                       textAlign: 'center',
-                      p: 3,
+                      p: { xs: 3, md: 4 },
                       borderRadius: 4,
                       cursor: 'pointer',
-                      transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-                      '&:hover': {
-                        transform: 'translateY(-4px)',
-                        boxShadow: '0 18px 30px rgba(15, 23, 42, 0.08)',
-                      },
+                      position: 'relative',
+                      overflow: 'hidden',
+                      border: '1px solid rgba(15,23,42,0.06)',
+                      transition: 'transform 0.3s cubic-bezier(0.22,1,0.36,1), box-shadow 0.3s ease, border-color 0.3s ease',
+                      '&:hover': { transform: 'translateY(-6px)', boxShadow: '0 22px 40px rgba(40,116,240,0.16)', borderColor: 'rgba(40,116,240,0.35)' },
+                      '&:hover .cat-cta': { opacity: 1, transform: 'translateY(0)' },
                     }}
                     onClick={() => {
                       notify({ severity: 'info', message: `Browsing ${category.label}` });
                       navigate(`/shop?category=${category.key}`);
                     }}
                   >
-                    <Avatar
-                      variant="rounded"
-                      src={category.thumbnail}
-                      alt={category.label}
-                      sx={{ width: 72, height: 72, mx: 'auto', mb: 2, bgcolor: 'primary.light' }}
+                    <Box sx={{ p: '3px', borderRadius: '50%', width: 'fit-content', mx: 'auto', mb: 2, background: ACCENT_GRADIENT }}>
+                      <Avatar variant="circular" src={category.thumbnail} alt={category.label} sx={{ width: 84, height: 84, border: '3px solid #fff', bgcolor: 'primary.light' }}>
+                        {category.label.charAt(0)}
+                      </Avatar>
+                    </Box>
+                    <Typography fontWeight={700}>{category.label}</Typography>
+                    <Typography
+                      className="cat-cta"
+                      variant="caption"
+                      sx={{ display: 'block', mt: 0.5, color: 'primary.main', fontWeight: 600, opacity: 0, transform: 'translateY(4px)', transition: 'opacity 0.3s ease, transform 0.3s ease' }}
                     >
-                      {category.label.charAt(0)}
-                    </Avatar>
-                    <Typography fontWeight={600}>{category.label}</Typography>
+                      Shop now →
+                    </Typography>
                   </Paper>
                 </Grid>
               ))}
@@ -565,13 +724,9 @@ function Home({ products, addToCart, error, loading }) {
           </Box>
         )}
 
-        <Box sx={{ mt: 10 }}>
-          <Typography variant="h4" fontWeight={700} textAlign="center">
-            Personalized For You
-          </Typography>
-          <Typography variant="body1" color="text.secondary" textAlign="center" sx={{ mb: 4 }}>
-            Based on your recent views, we think you might like these products!
-          </Typography>
+        {/* ====================== RECOMMENDATIONS ====================== */}
+        <Box sx={{ mt: 12 }}>
+          <SectionHeading eyebrow="For you" title="Personalized For You" subtitle="Based on your recent views, we think you might like these products." />
 
           {recError ? (
             <RecommendedError error={recError} onRetry={fetchRecs} />
@@ -600,56 +755,68 @@ function Home({ products, addToCart, error, loading }) {
           )}
         </Box>
 
-        <Box sx={{ mt: 10 }}>
-          <Typography variant="h4" fontWeight={700} textAlign="center">
-            Loved by creators & innovators
-          </Typography>
-          <Typography variant="body1" color="text.secondary" textAlign="center" sx={{ mb: 4 }}>
-            Real stories from customers building their dream setups with Fusion Electronics.
-          </Typography>
+        {/* ====================== TESTIMONIALS ====================== */}
+        <Box sx={{ mt: 12 }} data-reveal="true">
+          <SectionHeading eyebrow="Social proof" title="Loved by creators & innovators" subtitle="Real stories from customers building their dream setups with Fusion Electronics." />
           <Grid container spacing={3}>
             {testimonials.map(testimonial => (
               <Grid item xs={12} md={4} key={testimonial.name}>
-                <Paper elevation={0} sx={{ p: 4, height: '100%', borderRadius: 4 }}>
-                  <FormatQuoteRoundedIcon color="primary" />
-                  <Typography variant="body1" sx={{ my: 2 }}>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: 4,
+                    height: '100%',
+                    borderRadius: 4,
+                    border: '1px solid rgba(15,23,42,0.06)',
+                    position: 'relative',
+                    transition: 'transform 0.3s cubic-bezier(0.22,1,0.36,1), box-shadow 0.3s ease',
+                    '&:hover': { transform: 'translateY(-6px)', boxShadow: '0 24px 50px rgba(40,116,240,0.14)' },
+                  }}
+                >
+                  <FormatQuoteRoundedIcon sx={{ fontSize: 40, color: 'rgba(40,116,240,0.25)' }} />
+                  <Typography variant="body1" sx={{ my: 1.5, lineHeight: 1.7 }}>
                     “{testimonial.quote}”
                   </Typography>
-                  <Typography variant="subtitle1" fontWeight={700}>
-                    {testimonial.name}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {testimonial.role}
-                  </Typography>
+                  <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mt: 2 }}>
+                    <Avatar sx={{ background: ACCENT_GRADIENT, color: 'white', fontWeight: 700 }}>{testimonial.name.charAt(0)}</Avatar>
+                    <Box>
+                      <Typography variant="subtitle1" fontWeight={700} sx={{ lineHeight: 1.2 }}>
+                        {testimonial.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {testimonial.role}
+                      </Typography>
+                    </Box>
+                  </Stack>
                 </Paper>
               </Grid>
             ))}
           </Grid>
         </Box>
 
+        {/* ====================== NEWSLETTER ====================== */}
         <Paper
           elevation={0}
+          data-reveal="true"
           sx={{
-            mt: 10,
+            mt: 12,
             p: { xs: 4, md: 6 },
-            borderRadius: 5,
-            background: 'linear-gradient(120deg, rgba(15,23,42,0.95) 0%, rgba(30,64,175,0.85) 100%)',
+            borderRadius: 6,
+            position: 'relative',
+            overflow: 'hidden',
+            background: 'radial-gradient(120% 140% at 100% 0%, #1e40af 0%, #0f172a 60%)',
             color: 'white',
           }}
         >
-          <Grid container spacing={4} alignItems="center">
+          <Grid container spacing={4} alignItems="center" sx={{ position: 'relative', zIndex: 1 }}>
             <Grid item xs={12} md={7}>
               <Stack spacing={2}>
-                <Chip
-                  icon={<StarIcon fontSize="small" />}
-                  label="Join 50k+ tech enthusiasts"
-                  sx={{ alignSelf: 'flex-start', bgcolor: 'rgba(255,255,255,0.18)', color: 'white' }}
-                />
-                <Typography variant="h4" fontWeight={700}>
+                <Chip icon={<StarIcon fontSize="small" />} label="Join 50k+ tech enthusiasts" sx={{ alignSelf: 'flex-start', bgcolor: 'rgba(255,255,255,0.16)', color: 'white' }} />
+                <Typography variant="h4" fontWeight={800} sx={{ letterSpacing: '-0.02em' }}>
                   Unlock curated buying guides and exclusive launch alerts.
                 </Typography>
                 <Typography variant="body1" sx={{ opacity: 0.9 }}>
-                  Subscribe to the Weekly Signal newsletter to get bite-sized product breakdowns, setup inspiration, and member-only perks.
+                  Subscribe to the Weekly Signal newsletter for bite-sized product breakdowns, setup inspiration, and member-only perks.
                 </Typography>
                 <Stack direction="row" spacing={3} sx={{ color: 'rgba(255,255,255,0.7)' }}>
                   <Stack>
@@ -683,7 +850,7 @@ function Home({ products, addToCart, error, loading }) {
                     sx: { bgcolor: 'white', borderRadius: 2 },
                   }}
                 />
-                <Button variant="contained" size="large" endIcon={<ArrowForwardIcon />} type="submit">
+                <Button variant="contained" size="large" endIcon={<ArrowForwardIcon />} type="submit" sx={{ background: ACCENT_GRADIENT }}>
                   Get the newsletter
                 </Button>
               </Box>
@@ -691,23 +858,43 @@ function Home({ products, addToCart, error, loading }) {
           </Grid>
         </Paper>
 
-        <Divider sx={{ my: 10 }} />
+        <Divider sx={{ mt: 8, mb: 3 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: '0.2em' }}>
+            Trusted brands
+          </Typography>
+        </Divider>
 
-        <Stack direction="row" spacing={3} justifyContent="center" alignItems="center" flexWrap="wrap">
-          {brandInitials.map(brand => (
-            <Chip key={brand} icon={<StarIcon />} label={brand} sx={{ bgcolor: 'rgba(37, 99, 235, 0.08)' }} />
-          ))}
-        </Stack>
+        <Box className="ecom-marquee" data-reveal="true">
+          {/* 8 copies → the animated -50% shift lands exactly on a repeat
+              boundary (each half is 4× the brand list, always wider than the
+              viewport), so the loop is seamless and never shows an end. */}
+          <Box className="ecom-marquee__track">
+            {Array.from({ length: 8 }).flatMap((_, rep) =>
+              brandInitials.map((brand, j) => (
+                <Chip
+                  key={`${rep}-${j}`}
+                  icon={<StarIcon />}
+                  label={brand}
+                  sx={{ bgcolor: 'rgba(37, 99, 235, 0.08)', fontWeight: 600, px: 0.5, flex: '0 0 auto' }}
+                />
+              )),
+            )}
+          </Box>
+        </Box>
 
-        <Box sx={{ textAlign: 'center', mt: 6 }}>
-          <Typography variant="h5" fontWeight={600} gutterBottom>
+        {/* ====================== FINAL CTA ====================== */}
+        <Box sx={{ textAlign: 'center', mt: 10, mb: 4 }} data-reveal="true">
+          <Typography variant="h4" fontWeight={800} gutterBottom sx={{ letterSpacing: '-0.02em' }}>
             Ready to build your next-level setup?
           </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 560, mx: 'auto', mb: 3 }}>
+            Explore thousands of curated products, backed by concierge support and hassle-free returns.
+          </Typography>
           <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="center" spacing={2}>
-            <Button variant="contained" size="large" component={RouterLink} to="/shop" endIcon={<ArrowForwardIcon />}>
+            <Button variant="contained" size="large" component={RouterLink} to="/shop" endIcon={<ArrowForwardIcon />} sx={{ px: 4, py: 1.3, background: ACCENT_GRADIENT, boxShadow: '0 16px 38px rgba(40,116,240,0.35)' }}>
               View More Products
             </Button>
-            <Button variant="outlined" size="large" component={RouterLink} to="/support">
+            <Button variant="outlined" size="large" component={RouterLink} to="/support" sx={{ px: 4, py: 1.3 }}>
               Talk with a specialist
             </Button>
           </Stack>

--- a/src/tests/Home.test.js
+++ b/src/tests/Home.test.js
@@ -3,37 +3,19 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Home from '../pages/Home';
 
-// 1) Mock the ProductCard so it doesn't pull in useNavigate
+// Mock the ProductCard so it doesn't pull in useNavigate
 jest.mock('../components/ProductCard', () => ({ product }) => <div data-testid="product-card">{product.name}</div>);
 
-// 2) Mock the carousel so we don't exercise its internals
-jest.mock('react-material-ui-carousel', () => props => <div data-testid="carousel">{props.children}</div>);
-
-// 3) Mock all three banner images to simple strings
-jest.mock('../assets/images/summer-sale.jpg', () => 'summer.jpg');
-jest.mock('../assets/images/tech-gadgets.jpg', () => 'tech.jpg');
-jest.mock('../assets/images/trending-fashion.jpg', () => 'fashion.jpg');
+// Mock the 3D hero so tests never touch WebGL / three
+jest.mock('../components/HeroScene', () => () => <div data-testid="hero-scene" />);
 
 describe('<Home />', () => {
-  const bannerAlts = ['Summer Sale - Up to 50% Off', 'New Tech Gadgets', 'Trending Electronics'];
-
   const makeProducts = n =>
     Array.from({ length: n }, (_, i) => ({
       _id: String(i + 1),
       name: `Prod${i + 1}`,
       category: 'any',
     }));
-
-  it('renders the 3 banner images', () => {
-    render(
-      <MemoryRouter>
-        <Home products={[]} addToCart={() => {}} loading={false} error={null} />
-      </MemoryRouter>
-    );
-    bannerAlts.forEach(alt => {
-      expect(screen.getByAltText(alt)).toBeInTheDocument();
-    });
-  });
 
   it('shows a spinner when loading=true', () => {
     render(

--- a/src/tests/snapshots/__snapshots__/Footer.snapshot.test.js.snap
+++ b/src/tests/snapshots/__snapshots__/Footer.snapshot.test.js.snap
@@ -227,10 +227,10 @@ exports[`Footer snapshot matches the rendered markup 1`] = `
             Unlock early access to product drops, curated buying guides, and exclusive VIP offers.
           </p>
           <form
-            class="MuiBox-root css-1mcghfl"
+            class="MuiBox-root css-tmox95"
           >
             <div
-              class="MuiFormControl-root MuiTextField-root css-13brrgc-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root css-7j3kjf-MuiFormControl-root-MuiTextField-root"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
@@ -261,7 +261,7 @@ exports[`Footer snapshot matches the rendered markup 1`] = `
               </div>
             </div>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-iaznig-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1ovcde6-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="submit"
             >

--- a/src/tests/snapshots/__snapshots__/Home.snapshot.test.js.snap
+++ b/src/tests/snapshots/__snapshots__/Home.snapshot.test.js.snap
@@ -3,49 +3,544 @@
 exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] = `
 <DocumentFragment>
   <div
-    class="MuiBox-root css-nh9wik"
+    class="MuiBox-root css-rggzhz"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1oid2z0-MuiPaper-root"
+      aria-hidden="true"
+      class="home-aurora MuiBox-root css-0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1s9873g-MuiPaper-root"
     >
       <div
-        class="MuiGrid-root MuiGrid-container css-194ypub-MuiGrid-root"
+        aria-hidden="true"
+        class="MuiBox-root css-6puuyi"
+      />
+      <div
+        class="MuiGrid-root MuiGrid-container css-1970r3u-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-ez2bkn-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 MuiGrid-grid-lg-6 css-1ltvqgc-MuiGrid-root"
         >
           <div
-            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-j0hi6n-MuiChip-root"
+            class="MuiStack-root css-15rldda-MuiStack-root"
+          >
+            <div
+              class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1hrptto-MuiChip-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-zplvu1-MuiSvgIcon-root"
+                data-testid="AutoAwesomeRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m19.46 8 .79-1.75L22 5.46c.39-.18.39-.73 0-.91l-1.75-.79L19.46 2c-.18-.39-.73-.39-.91 0l-.79 1.75-1.76.79c-.39.18-.39.73 0 .91l1.75.79.79 1.76c.18.39.74.39.92 0M11.5 9.5 9.91 6c-.35-.78-1.47-.78-1.82 0L6.5 9.5 3 11.09c-.78.36-.78 1.47 0 1.82l3.5 1.59L8.09 18c.36.78 1.47.78 1.82 0l1.59-3.5 3.5-1.59c.78-.36.78-1.47 0-1.82zm7.04 6.5-.79 1.75-1.75.79c-.39.18-.39.73 0 .91l1.75.79.79 1.76c.18.39.73.39.91 0l.79-1.75 1.76-.79c.39-.18.39-.73 0-.91l-1.75-.79-.79-1.76c-.18-.39-.74-.39-.92 0"
+                />
+              </svg>
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+              >
+                Summer Tech Edit
+              </span>
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h2 css-1zkfne-MuiTypography-root"
+            >
+              Gear that upgrades every 
+              <span
+                class="MuiBox-root css-759tda"
+              >
+                moment
+              </span>
+               of your day.
+            </h2>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-fgtcla-MuiTypography-root"
+            >
+              Discover handpicked gadgets, smart-home essentials, and creator-ready accessories curated by our in-house specialists.
+            </p>
+            <div
+              class="MuiStack-root css-br5rt4-MuiStack-root"
+            >
+              <a
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-14y7gqm-MuiButtonBase-root-MuiButton-root"
+                href="/shop"
+                tabindex="0"
+              >
+                Shop best sellers
+                <span
+                  class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeLarge css-z4rqyd-MuiButton-endIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="ArrowForwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </a>
+              <a
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorInherit MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorInherit css-sipo0v-MuiButtonBase-root-MuiButton-root"
+                href="/about"
+                tabindex="0"
+              >
+                Learn our story
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiStack-root css-19ln6u5-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-cuozto-MuiStack-root"
+              >
+                <h5
+                  class="MuiTypography-root MuiTypography-h5 css-14ksg3c-MuiTypography-root"
+                >
+                  4.8/5
+                </h5>
+                <span
+                  class="MuiTypography-root MuiTypography-caption css-rbauum-MuiTypography-root"
+                >
+                  12k+ reviews
+                </span>
+              </div>
+              <hr
+                class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1s9015k-MuiDivider-root"
+              />
+              <div
+                class="MuiStack-root css-cuozto-MuiStack-root"
+              >
+                <h5
+                  class="MuiTypography-root MuiTypography-h5 css-14ksg3c-MuiTypography-root"
+                >
+                  48h
+                </h5>
+                <span
+                  class="MuiTypography-root MuiTypography-caption css-rbauum-MuiTypography-root"
+                >
+                  Avg. delivery
+                </span>
+              </div>
+              <hr
+                class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1s9015k-MuiDivider-root"
+              />
+              <div
+                class="MuiStack-root css-cuozto-MuiStack-root"
+              >
+                <h5
+                  class="MuiTypography-root MuiTypography-h5 css-14ksg3c-MuiTypography-root"
+                >
+                  50k+
+                </h5>
+                <span
+                  class="MuiTypography-root MuiTypography-caption css-rbauum-MuiTypography-root"
+                >
+                  Happy members
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 MuiGrid-grid-lg-6 css-11umzgt-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1chm0p1-MuiPaper-root"
+          >
+            <div
+              class="MuiStack-root css-dghotf-MuiStack-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-3o1l0h-MuiSvgIcon-root"
+                data-testid="StarRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-3o1l0h-MuiSvgIcon-root"
+                data-testid="StarRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-3o1l0h-MuiSvgIcon-root"
+                data-testid="StarRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-3o1l0h-MuiSvgIcon-root"
+                data-testid="StarRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-3o1l0h-MuiSvgIcon-root"
+                data-testid="StarRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08z"
+                />
+              </svg>
+            </div>
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+            >
+              Trusted by 50,000+ builders
+            </h6>
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-164j3z1-MuiTypography-root"
+            >
+              Premium gear, expert curation, and delivery you can count on.
+            </p>
+            <div
+              class="MuiStack-root css-1l9qugs-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-12f6rge-MuiStack-root"
+              >
+                <div
+                  class="MuiBox-root css-1ijcprm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="BoltRoundedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10.67 21c-.35 0-.62-.31-.57-.66L11 14H7.5c-.88 0-.33-.75-.31-.78 1.26-2.23 3.15-5.53 5.65-9.93.1-.18.3-.29.5-.29.35 0 .62.31.57.66l-.9 6.34h3.51c.4 0 .62.19.4.66-3.29 5.74-5.2 9.09-5.75 10.05-.1.18-.29.29-.5.29"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1survsf-MuiTypography-root"
+                >
+                  Same-week express shipping
+                </p>
+              </div>
+              <div
+                class="MuiStack-root css-12f6rge-MuiStack-root"
+              >
+                <div
+                  class="MuiBox-root css-1ijcprm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="VerifiedRoundedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m23 12-2.44-2.79.34-3.69-3.61-.82-1.89-3.2L12 2.96 8.6 1.5 6.71 4.69 3.1 5.5l.34 3.7L1 12l2.44 2.79-.34 3.7 3.61.82L8.6 22.5l3.4-1.47 3.4 1.46 1.89-3.19 3.61-.82-.34-3.69zM9.38 16.01 7 13.61a.9959.9959 0 0 1 0-1.41l.07-.07c.39-.39 1.03-.39 1.42 0l1.61 1.62 5.15-5.16c.39-.39 1.03-.39 1.42 0l.07.07c.39.39.39 1.02 0 1.41l-5.92 5.94c-.41.39-1.04.39-1.44 0"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1survsf-MuiTypography-root"
+                >
+                  Authentic, warrantied products
+                </p>
+              </div>
+              <div
+                class="MuiStack-root css-12f6rge-MuiStack-root"
+              >
+                <div
+                  class="MuiBox-root css-1ijcprm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="LockIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1z"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1survsf-MuiTypography-root"
+                >
+                  Encrypted, secure checkout
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthXl css-19r6kue-MuiContainer-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5 css-16zk4t2-MuiGrid-root"
+        data-reveal="true"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1x0vk0d-MuiPaper-root"
+          >
+            <div
+              class="MuiStack-root css-10kbc59-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1tswe26"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
+                  data-testid="LocalShippingIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5m13.5-9 1.96 2.5H17V9.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5"
+                  />
+                </svg>
+              </div>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              >
+                Free 2-Day Delivery
+              </h6>
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
+              >
+                Complimentary express shipping on all orders over $75 in the continental US.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1x0vk0d-MuiPaper-root"
+          >
+            <div
+              class="MuiStack-root css-10kbc59-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1tswe26"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
+                  data-testid="HeadsetMicIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 1c-4.97 0-9 4.03-9 9v7c0 1.66 1.34 3 3 3h3v-8H5v-2c0-3.87 3.13-7 7-7s7 3.13 7 7v2h-4v8h4v1h-7v2h6c1.66 0 3-1.34 3-3V10c0-4.97-4.03-9-9-9"
+                  />
+                </svg>
+              </div>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              >
+                Concierge Support
+              </h6>
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
+              >
+                Dedicated product specialists available 24/7 to help you level up your setup.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1x0vk0d-MuiPaper-root"
+          >
+            <div
+              class="MuiStack-root css-10kbc59-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1tswe26"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
+                  data-testid="LockIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1z"
+                  />
+                </svg>
+              </div>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              >
+                Secure Checkout
+              </h6>
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
+              >
+                End-to-end encryption and trusted payment partners keep your data protected.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1x0vk0d-MuiPaper-root"
+          >
+            <div
+              class="MuiStack-root css-10kbc59-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1tswe26"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
+                  data-testid="SyncIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+                  />
+                </svg>
+              </div>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              >
+                30-Day Returns
+              </h6>
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
+              >
+                Love it or send it back. Hassle-free returns on every single purchase.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1rheo5w"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-fll3ht-MuiTypography-root"
+        >
+          Editor's picks
+        </span>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 css-1a94ck3-MuiTypography-root"
+        >
+          Featured Products
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1ts76t1-MuiTypography-root"
+        >
+          Our specialists' top picks for this month — tried, tested, and loved.
+        </p>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-480o17-MuiGrid-root"
+      />
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-k3uyo2-MuiPaper-root"
+        data-reveal="true"
+      >
+        <div
+          aria-hidden="true"
+          class="MuiBox-root css-uppnoe"
+        />
+        <div
+          aria-hidden="true"
+          class="MuiBox-root css-151s14z"
+        />
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-8w0he4-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8 css-9drkqd-MuiGrid-root"
           >
             <span
-              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+              class="MuiTypography-root MuiTypography-body1 css-13l0rub-MuiTypography-root"
             >
-              Summer Tech Edit
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-xtuuzo-MuiSvgIcon-root"
+                data-testid="LocalOfferRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m21.41 11.58-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58s1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41s-.23-1.06-.59-1.42M5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7"
+                />
+              </svg>
+               Member exclusive
             </span>
-          </div>
-          <div
-            class="MuiBox-root css-0"
-          >
             <h3
-              class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom css-84pe2t-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h3 css-9uq949-MuiTypography-root"
             >
-              Gear that upgrades every moment of your day.
+              Up to 40% off premium audio & smart home.
             </h3>
             <p
-              class="MuiTypography-root MuiTypography-body1 css-1cdo9ri-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-d0m0rj-MuiTypography-root"
             >
-              Discover handpicked gadgets, smart home essentials, and creator-ready accessories curated by our in-house specialists.
+              Hand-picked bundles refreshed every week — with free express shipping, easy 30-day returns, and concierge setup help on every order.
             </p>
           </div>
           <div
-            class="MuiStack-root css-w7gobd-MuiStack-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-a5wcg0-MuiGrid-root"
           >
             <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-jh47zj-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-s7ry8g-MuiButtonBase-root-MuiButton-root"
               href="/shop"
               tabindex="0"
             >
-              Shop best sellers
+              Shop the collection
               <span
                 class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeLarge css-z4rqyd-MuiButton-endIcon"
               >
@@ -65,337 +560,31 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />
             </a>
-            <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorInherit MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorInherit css-1ny6pps-MuiButtonBase-root-MuiButton-root"
-              href="/about"
-              tabindex="0"
-            >
-              Learn our story
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </a>
-          </div>
-          <div
-            class="MuiStack-root css-1heabyg-MuiStack-root"
-          >
-            <div
-              class="MuiStack-root css-j3ygch-MuiStack-root"
-            >
-              <h5
-                class="MuiTypography-root MuiTypography-h5 css-bezmlo-MuiTypography-root"
-              >
-                4.8/5
-              </h5>
-              <span
-                class="MuiTypography-root MuiTypography-caption css-1k6v7j9-MuiTypography-root"
-              >
-                Rated by 12k+ customers
-              </span>
-            </div>
-            <div
-              class="MuiStack-root css-j3ygch-MuiStack-root"
-            >
-              <h5
-                class="MuiTypography-root MuiTypography-h5 css-bezmlo-MuiTypography-root"
-              >
-                48h
-              </h5>
-              <span
-                class="MuiTypography-root MuiTypography-caption css-1k6v7j9-MuiTypography-root"
-              >
-                Average delivery time
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-pttzxn-MuiGrid-root"
-        >
-          <div
-            class="MuiBox-root css-1ky0u8f"
-          >
-            <div
-              data-testid="carousel"
-            >
-              <div
-                class="MuiBox-root css-1o3fej"
-              >
-                <img
-                  alt="Summer Sale - Up to 50% Off"
-                  class="MuiBox-root css-105ny13"
-                  src="fashion.png"
-                />
-                <div
-                  class="MuiBox-root css-mqz7k4"
-                >
-                  <h5
-                    class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom css-gm0pd4-MuiTypography-root"
-                  >
-                    Summer Sale - Up to 50% Off
-                  </h5>
-                  <p
-                    class="MuiTypography-root MuiTypography-body2 css-vz89pj-MuiTypography-root"
-                  >
-                    Shop now for the best deals on summer essentials!
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root css-1o3fej"
-              >
-                <img
-                  alt="New Tech Gadgets"
-                  class="MuiBox-root css-105ny13"
-                  src="fashion.png"
-                />
-                <div
-                  class="MuiBox-root css-mqz7k4"
-                >
-                  <h5
-                    class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom css-gm0pd4-MuiTypography-root"
-                  >
-                    New Tech Gadgets
-                  </h5>
-                  <p
-                    class="MuiTypography-root MuiTypography-body2 css-vz89pj-MuiTypography-root"
-                  >
-                    Explore the latest in tech and gadgets.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root css-1o3fej"
-              >
-                <img
-                  alt="Trending Electronics"
-                  class="MuiBox-root css-105ny13"
-                  src="fashion.png"
-                />
-                <div
-                  class="MuiBox-root css-mqz7k4"
-                >
-                  <h5
-                    class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom css-gm0pd4-MuiTypography-root"
-                  >
-                    Trending Electronics
-                  </h5>
-                  <p
-                    class="MuiTypography-root MuiTypography-body2 css-vz89pj-MuiTypography-root"
-                  >
-                    Discover the newest trends in electronics this season.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiContainer-root MuiContainer-maxWidthXl css-19r6kue-MuiContainer-root"
-    >
-      <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-13lr83m-MuiGrid-root"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
-        >
-          <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-i2c3vo-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-1h9mz9o-MuiStack-root"
-            >
-              <div
-                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-a0lbhu-MuiAvatar-root"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
-                  data-testid="LocalShippingIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5m13.5-9 1.96 2.5H17V9.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiBox-root css-0"
-              >
-                <h6
-                  class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom css-f5tzpe-MuiTypography-root"
-                >
-                  Free 2-Day Delivery
-                </h6>
-                <p
-                  class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
-                >
-                  Complimentary express shipping on all orders over $75 in the continental US.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
-        >
-          <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-i2c3vo-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-1h9mz9o-MuiStack-root"
-            >
-              <div
-                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-a0lbhu-MuiAvatar-root"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
-                  data-testid="HeadsetMicIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 1c-4.97 0-9 4.03-9 9v7c0 1.66 1.34 3 3 3h3v-8H5v-2c0-3.87 3.13-7 7-7s7 3.13 7 7v2h-4v8h4v1h-7v2h6c1.66 0 3-1.34 3-3V10c0-4.97-4.03-9-9-9"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiBox-root css-0"
-              >
-                <h6
-                  class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom css-f5tzpe-MuiTypography-root"
-                >
-                  Concierge Support
-                </h6>
-                <p
-                  class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
-                >
-                  Dedicated product specialists available 24/7 to help you level up your setup.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
-        >
-          <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-i2c3vo-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-1h9mz9o-MuiStack-root"
-            >
-              <div
-                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-a0lbhu-MuiAvatar-root"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
-                  data-testid="LockIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiBox-root css-0"
-              >
-                <h6
-                  class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom css-f5tzpe-MuiTypography-root"
-                >
-                  Secure Checkout
-                </h6>
-                <p
-                  class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
-                >
-                  End-to-end encryption and trusted payment partners keep your data protected.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-10voxkt-MuiGrid-root"
-        >
-          <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-i2c3vo-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-1h9mz9o-MuiStack-root"
-            >
-              <div
-                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-a0lbhu-MuiAvatar-root"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-tzssek-MuiSvgIcon-root"
-                  data-testid="SyncIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiBox-root css-0"
-              >
-                <h6
-                  class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom css-f5tzpe-MuiTypography-root"
-                >
-                  30-Day Returns
-                </h6>
-                <p
-                  class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
-                >
-                  Love it or send it back. Hassle-free returns on every single purchase.
-                </p>
-              </div>
-            </div>
           </div>
         </div>
       </div>
       <div
-        class="MuiBox-root css-co4xce"
-      >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-1313egv-MuiTypography-root"
-        >
-          Featured Products
-        </h4>
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
-        >
-          Check out our top picks for this month!
-        </p>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-480o17-MuiGrid-root"
-      />
-      <div
-        class="MuiBox-root css-h8m1q6"
+        class="MuiBox-root css-ib9iq6"
+        data-reveal="true"
       >
         <div
-          class="MuiStack-root css-kpi0vi-MuiStack-root"
+          class="MuiStack-root css-1j573xm-MuiStack-root"
         >
           <div
             class="MuiBox-root css-0"
           >
+            <span
+              class="MuiTypography-root MuiTypography-body1 css-1a5ihe5-MuiTypography-root"
+            >
+              Just landed
+            </span>
             <h4
-              class="MuiTypography-root MuiTypography-h4 css-1313egv-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h4 css-1a94ck3-MuiTypography-root"
             >
               New Arrivals
             </h4>
             <p
-              class="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-191mh0w-MuiTypography-root"
             >
               Fresh drops from brands we love. Updated every week.
             </p>
@@ -427,22 +616,31 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
           </a>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-19h80yh-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-480o17-MuiGrid-root"
         />
       </div>
       <div
-        class="MuiBox-root css-ib9iq6"
+        class="MuiBox-root css-1c9l5hu"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-uqrixu-MuiTypography-root"
+        <div
+          class="MuiBox-root css-1rheo5w"
         >
-          Personalized For You
-        </h4>
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-1c0ebag-MuiTypography-root"
-        >
-          Based on your recent views, we think you might like these products!
-        </p>
+          <span
+            class="MuiTypography-root MuiTypography-body1 css-fll3ht-MuiTypography-root"
+          >
+            For you
+          </span>
+          <h4
+            class="MuiTypography-root MuiTypography-h4 css-1a94ck3-MuiTypography-root"
+          >
+            Personalized For You
+          </h4>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ts76t1-MuiTypography-root"
+          >
+            Based on your recent views, we think you might like these products.
+          </p>
+        </div>
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-1khbuii-MuiPaper-root-MuiAlert-root"
           role="alert"
@@ -504,18 +702,28 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
         </div>
       </div>
       <div
-        class="MuiBox-root css-ib9iq6"
+        class="MuiBox-root css-1c9l5hu"
+        data-reveal="true"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 css-uqrixu-MuiTypography-root"
+        <div
+          class="MuiBox-root css-1rheo5w"
         >
-          Loved by creators & innovators
-        </h4>
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-1c0ebag-MuiTypography-root"
-        >
-          Real stories from customers building their dream setups with Fusion Electronics.
-        </p>
+          <span
+            class="MuiTypography-root MuiTypography-body1 css-fll3ht-MuiTypography-root"
+          >
+            Social proof
+          </span>
+          <h4
+            class="MuiTypography-root MuiTypography-h4 css-1a94ck3-MuiTypography-root"
+          >
+            Loved by creators & innovators
+          </h4>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ts76t1-MuiTypography-root"
+          >
+            Real stories from customers building their dream setups with Fusion Electronics.
+          </p>
+        </div>
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-zow5z4-MuiGrid-root"
         >
@@ -523,11 +731,11 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
           >
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-swggzx-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1p6teqz-MuiPaper-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium css-ci5apu-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-12zb204-MuiSvgIcon-root"
                 data-testid="FormatQuoteRoundedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -537,31 +745,44 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 />
               </svg>
               <p
-                class="MuiTypography-root MuiTypography-body1 css-izaxaw-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 css-1jrihl2-MuiTypography-root"
               >
                 “Fusion Electronics curates gear I didn’t even know I needed. The quality and delivery speed are unmatched.”
               </p>
-              <h6
-                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              <div
+                class="MuiStack-root css-5gq4xp-MuiStack-root"
               >
-                Riley Chen
-              </h6>
-              <span
-                class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
-              >
-                Content Creator
-              </span>
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-r4yvxi-MuiAvatar-root"
+                >
+                  R
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-12787gl-MuiTypography-root"
+                  >
+                    Riley Chen
+                  </h6>
+                  <span
+                    class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+                  >
+                    Content Creator
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
           >
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-swggzx-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1p6teqz-MuiPaper-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium css-ci5apu-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-12zb204-MuiSvgIcon-root"
                 data-testid="FormatQuoteRoundedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -571,31 +792,44 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 />
               </svg>
               <p
-                class="MuiTypography-root MuiTypography-body1 css-izaxaw-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 css-1jrihl2-MuiTypography-root"
               >
                 “From smart home tech to productivity gadgets, everything arrives perfectly packaged and ready to go.”
               </p>
-              <h6
-                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              <div
+                class="MuiStack-root css-5gq4xp-MuiStack-root"
               >
-                Morgan Patel
-              </h6>
-              <span
-                class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
-              >
-                Startup Founder
-              </span>
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-r4yvxi-MuiAvatar-root"
+                >
+                  M
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-12787gl-MuiTypography-root"
+                  >
+                    Morgan Patel
+                  </h6>
+                  <span
+                    class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+                  >
+                    Startup Founder
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
           >
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-swggzx-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1p6teqz-MuiPaper-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium css-ci5apu-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-12zb204-MuiSvgIcon-root"
                 data-testid="FormatQuoteRoundedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -605,29 +839,43 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 />
               </svg>
               <p
-                class="MuiTypography-root MuiTypography-body1 css-izaxaw-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 css-1jrihl2-MuiTypography-root"
               >
                 “Their support team is next level. They helped me switch out a device overnight before a big launch.”
               </p>
-              <h6
-                class="MuiTypography-root MuiTypography-subtitle1 css-1isisa7-MuiTypography-root"
+              <div
+                class="MuiStack-root css-5gq4xp-MuiStack-root"
               >
-                Devon Brooks
-              </h6>
-              <span
-                class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
-              >
-                Product Designer
-              </span>
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-r4yvxi-MuiAvatar-root"
+                >
+                  D
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-12787gl-MuiTypography-root"
+                  >
+                    Devon Brooks
+                  </h6>
+                  <span
+                    class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+                  >
+                    Product Designer
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-hll42t-MuiPaper-root"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-15hkupb-MuiPaper-root"
+        data-reveal="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-xtlx1y-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-755wzi-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 css-1a4ufwv-MuiGrid-root"
@@ -636,7 +884,7 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
               class="MuiStack-root css-1sazv7p-MuiStack-root"
             >
               <div
-                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-cjy1do-MuiChip-root"
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ozf5ii-MuiChip-root"
               >
                 <svg
                   aria-hidden="true"
@@ -656,14 +904,14 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 </span>
               </div>
               <h4
-                class="MuiTypography-root MuiTypography-h4 css-1313egv-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h4 css-1a94ck3-MuiTypography-root"
               >
                 Unlock curated buying guides and exclusive launch alerts.
               </h4>
               <p
                 class="MuiTypography-root MuiTypography-body1 css-l9v3kn-MuiTypography-root"
               >
-                Subscribe to the Weekly Signal newsletter to get bite-sized product breakdowns, setup inspiration, and member-only perks.
+                Subscribe to the Weekly Signal newsletter for bite-sized product breakdowns, setup inspiration, and member-only perks.
               </p>
               <div
                 class="MuiStack-root css-9mh1d2-MuiStack-root"
@@ -756,7 +1004,7 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-jh47zj-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-hiastx-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="submit"
               >
@@ -784,146 +1032,1008 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
           </div>
         </div>
       </div>
-      <hr
-        class="MuiDivider-root MuiDivider-fullWidth css-ickpwe-MuiDivider-root"
-      />
       <div
-        class="MuiStack-root css-chr5zy-MuiStack-root"
+        class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren css-ovpxpp-MuiDivider-root"
+        role="separator"
+      >
+        <span
+          class="MuiDivider-wrapper css-qywfm8-MuiDivider-wrapper"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-overline css-w9l2s1-MuiTypography-root"
+          >
+            Trusted brands
+          </span>
+        </span>
+      </div>
+      <div
+        class="ecom-marquee MuiBox-root css-0"
+        data-reveal="true"
       >
         <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
+          class="ecom-marquee__track MuiBox-root css-0"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            SONY
-          </span>
-        </div>
-        <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            BOSE
-          </span>
-        </div>
-        <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            LG
-          </span>
-        </div>
-        <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            SAMSUNG
-          </span>
-        </div>
-        <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            ANKER
-          </span>
-        </div>
-        <div
-          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-ijuis7-MuiChip-root"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
-            data-testid="StarIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            <path
-              d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-            />
-          </svg>
-          <span
-            class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
           >
-            APPLE
-          </span>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SONY
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              BOSE
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              LG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              SAMSUNG
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              ANKER
+            </span>
+          </div>
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1ndbvn4-MuiChip-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-i4bv87-MuiSvgIcon-root"
+              data-testid="StarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              APPLE
+            </span>
+          </div>
         </div>
       </div>
       <div
-        class="MuiBox-root css-sznkde"
+        class="MuiBox-root css-y5loaw"
+        data-reveal="true"
       >
-        <h5
-          class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom css-1n80bwy-MuiTypography-root"
+        <h4
+          class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-8n4oy0-MuiTypography-root"
         >
           Ready to build your next-level setup?
-        </h5>
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-4lc2fc-MuiTypography-root"
+        >
+          Explore thousands of curated products, backed by concierge support and hassle-free returns.
+        </p>
         <div
           class="MuiStack-root css-67e3wp-MuiStack-root"
         >
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-jh47zj-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary css-1vlhm5z-MuiButtonBase-root-MuiButton-root"
             href="/shop"
             tabindex="0"
           >
@@ -948,7 +2058,7 @@ exports[`Home snapshot matches the rendered markup (loaded, empty products) 1`] 
             />
           </a>
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary css-9y1egq-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary css-1w2vnoh-MuiButtonBase-root-MuiButton-root"
             href="/support"
             tabindex="0"
           >


### PR DESCRIPTION
## Summary
Complete redesign of the storefront homepage — a premium, professional, eye-catching landing page with a procedural 3D hero, while keeping all product/recommendation/newsletter functionality intact.

### 3D hero (`src/components/HeroScene.jsx`)
- Procedural react-three-fiber backdrop: glossy metallic **torus-knot** + floating tech shapes (brand blue/indigo/pink/sky), inline **Lightformer** reflections, sparkle field — no `.glb/.hdr`/image assets.
- **Cursor-reactive** parallax.
- Lazy-loaded; **GPU-tier gated** with reduced-motion / WebGL-failure / context-loss fallbacks → weak devices keep the CSS gradient hero. three/drei sit in a lazy chunk.

### Home redesign (`src/pages/Home.jsx`)
- Dark cinematic hero: white headline + gradient accent word, glass trust card, stat row, gradient CTAs.
- Gradient value-prop cards, centered/enlarged category cards, refreshed testimonials, newsletter band.
- Replaced the image carousel with a **clean CSS spotlight promo band**.
- **Infinite brand marquee** (seamless), soft page aurora, one-shot entrance animation (never leaves content hidden).

### Shared `ProductCard`
- White image area so product photos blend, **divider** between media and content, hover image-zoom + lift, gradient add-to-cart CTA.

### Footer
- Insider-List form is now single-row (input + send button inline).

### Notes
- Contrast bug fixed (global `h1,h2,h3{color:#333}` was overriding the hero's white text).
- Iterated against the running app with Playwright (desktop + mobile verified).

## Testing
- `jest` → **78 passed / 30 suites**. Updated Home + Footer snapshots; removed the obsolete banner test.
- `npm run build` compiles (only the pre-existing `@mediapipe` source-map warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)